### PR TITLE
Allowing ctrl-c to quit

### DIFF
--- a/plugin/skybison.vim
+++ b/plugin/skybison.vim
@@ -202,7 +202,7 @@ function SkyBison(initcmdline)
 			end
 			let l:ctrlv = 0
 			let l:cmdline.=l:input
-		elseif l:input == "\<esc>"
+		elseif l:input == "\<esc>" || l:input == "\<c-c>"
 			return s:RunCommandAndQuit("")
 		elseif l:input == "\<c-v>"
 			let l:ctrlv = 1


### PR DESCRIPTION
I believe some users(including me obviously) are more accustomed to using ctrl-c to quit the command line. The fix is just a simple one line patch.
