### PR TITLE
Handle unlisted buffers

### DIFF
--- a/plugin/skybison.vim
+++ b/plugin/skybison.vim
@@ -20,7 +20,7 @@ function s:RunCommandAndQuit(cmdline)
 	" reset changed settings
 	let &laststatus = s:initlaststatus
 	let &showmode = s:initshowmode
-	bdelete!
+	silent! hide
 	execute s:initwinnr."wincmd w"
 	redraw
 
@@ -80,6 +80,7 @@ function SkyBison(initcmdline)
 	setlocal nocursorline
 	setlocal nonumber
 	setlocal nowrap
+	setlocal bufhidden=delete
 	if exists("&relativenumber")
 		setlocal norelativenumber
 	endif


### PR DESCRIPTION
If you called SkyBison from an unlisted buffer, :bdelete! on SkyBison's
buffer would delete both of them and leave you with an empty buffer.
