### PR TITLE
Added 'winheight' saving/restoring.

### DIFF
--- a/plugin/skybison.vim
+++ b/plugin/skybison.vim
@@ -21,6 +21,7 @@ function s:RunCommandAndQuit(cmdline)
 	let &laststatus = s:initlaststatus
 	let &showmode = s:initshowmode
 	let &shellslash = s:initshellslash
+	let &winheight = s:winheight
 	silent! hide
 	execute s:initwinnr."wincmd w"
 	execute s:winsizecmd
@@ -67,6 +68,8 @@ function SkyBison(initcmdline)
 	let s:initshellslash = &shellslash
 	let &shellslash = 1
 	let s:initwinnr = winnr()
+	let s:winheight = &winheight
+	let &winheight = 1
 
 	" setup output window
 	botright 11new


### PR DESCRIPTION
Hi, Paradigm.

**Why?**

I use a lightweight version of the "Rolodex" concept: `set winheight=999`.

Because SkyBison assumes the default value for `winheight` and arbitrarily sets the height of the useful part of the plugin's window we end up in a weird situation:

![original behavior](https://f.cloud.github.com/assets/344335/1499904/f04ca0ac-4866-11e3-9918-f486985bf95e.png)

**How?**

I've added three lines to the existing logic that:
- save the value of `winheight`
- set it to `1` (the default value)
- restore it to its initial value upon quit

Result:

![modified behavior](https://f.cloud.github.com/assets/344335/1499913/23aba72c-4867-11e3-8011-a9ca794a6615.png)

I'm aware that those changes are very specific (to me) but they seem relatively harmless.
