### PR TITLE
Add ability to quit with CTRL-c

### DIFF
--- a/plugin/skybison.vim
+++ b/plugin/skybison.vim
@@ -250,7 +250,7 @@ function SkyBison(initcmdline)
 			end
 			let l:ctrlv = 0
 			let l:cmdline.=l:input
-		elseif l:input == "\<esc>"
+		elseif l:input == "\<esc>" || l:input == "\<c-c>"
 			let l:cmdline = ""
 			break " run cmdline outside of try/catch
 		elseif l:input == "\<c-v>"


### PR DESCRIPTION
This turned out to be super simple. Closes #26.

Tested on Mac OS X 10.11.6 and Vim 7.4.
